### PR TITLE
Added delay on Scene Change/Reload

### DIFF
--- a/Assets/Scenes/Under.unity
+++ b/Assets/Scenes/Under.unity
@@ -462,6 +462,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 102099335, guid: 2853bc85ada247af5a5d460618dab24e, type: 3}
+      propertyPath: sceneLoadDelay
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7769298114784146834, guid: 2853bc85ada247af5a5d460618dab24e, type: 3}
       propertyPath: m_RootOrder
       value: 5

--- a/Assets/Scripts/CollisionHandler.cs
+++ b/Assets/Scripts/CollisionHandler.cs
@@ -5,27 +5,40 @@ using UnityEngine.SceneManagement;
 
 public class CollisionHandler : MonoBehaviour
 {
+
+    [SerializeField] float sceneLoadDelay = 1;
+
     private void OnCollisionEnter(Collision other)
     { 
         switch (other.gameObject.tag)
-        { 
-            case "Friendly":
-                Debug.Log("Hit Friendly");
-                break;
-            
+        {           
             case "Start":
                 Debug.Log("Hit Start");
                 break;
 
             case "Finish":
                 Debug.Log("Hit Finish");
-                LoadNextLevel();
+                SuccessSequence();
                 break;
-            
+
             default:
-                ReloadLevel();
+                CrashSequence();
                 break;
         }    
+    }
+
+    void SuccessSequence()
+    {
+        GetComponent<PlayerController>().enabled = false;
+        GetComponent<PlayerController>().audioSource.Stop();
+        Invoke("LoadNextLevel", sceneLoadDelay);
+    }
+
+    void CrashSequence()
+    {
+        GetComponent<PlayerController>().enabled = false;
+        GetComponent<PlayerController>().audioSource.Stop();
+        Invoke("ReloadLevel", sceneLoadDelay);
     }
 
     void ReloadLevel()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class PlayerController : MonoBehaviour
 {
     Rigidbody rocketRb;
-    AudioSource audioSource;
+    public AudioSource audioSource;
 
     [SerializeField] float mainThrust = 1000;
     [SerializeField] float rotationSpeed = 100;


### PR DESCRIPTION
- When the player crashes with an obstacle or the ground, the controls are disabled and the scene reloads after 1 second.
- When the player reaches the finish area, the controls are disabled and the next scene loads after 1 second